### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (https://www.mikealrogers.com/)",
   "license": "(Apache-2.0 AND MIT)",
   "devDependencies": {
-    "aegir": "^20.5.1",
-    "hundreds": "0.0.2",
-    "tsame": "^2.0.1"
+    "aegir": "^31.0.1",
+    "assert": "^2.0.0",
+    "buffer": "^6.0.3",
+    "hundreds": "0.0.9"
   },
   "dependencies": {
-    "cids": "~0.7.2"
+    "cids": "^1.1.6"
   },
   "repository": {
     "type": "git",

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -3,9 +3,9 @@
 const _codec = require('../')
 const CID = require('cids')
 const assert = require('assert')
-const tsame = require('tsame')
+const { Buffer } = require('buffer')
+const { expect } = require('aegir/utils/chai')
 
-const same = (...args) => assert.ok(tsame(...args))
 const test = it
 
 /* very bad dag codec for testing */
@@ -38,17 +38,17 @@ test('test encode/decode', () => {
   const codec = create()
   const buffer = codec.encode({ hello: 'world' })
   const obj = codec.decode(buffer)
-  same(obj, { hello: 'world' })
+  expect(obj).to.deep.equal({ hello: 'world' })
 })
 
 test('test codec property', () => {
   const codec = create()
-  same(codec.codec, 'terrible-dag')
+  expect(codec).to.have.property('codec', 'terrible-dag')
   let threw = false
   try {
     codec.codec = 'blah'
   } catch (e) {
-    same(e.message, 'Read-only property')
+    expect(e).to.have.property('message', 'Read-only property')
     threw = true
   }
   assert(threw)

--- a/test/reader.spec.js
+++ b/test/reader.spec.js
@@ -3,9 +3,8 @@
 const { CodecInterface } = require('../')
 const CID = require('cids')
 const assert = require('assert')
-const tsame = require('tsame')
+const { expect } = require('aegir/utils/chai')
 
-const same = (...args) => assert.ok(tsame(...args))
 const test = it
 
 const link = new CID('zdpuAtX7ZibcWdSKQwiDCkPjWwRvtcKCPku9H7LhgA4qJW4Wk')
@@ -27,33 +26,33 @@ const getReader = () => mock.reader({ decode: () => fixture })
 test('get path', () => {
   const reader = getReader()
   const one = reader.get('/a/1').value
-  same(one, 1)
+  expect(one).to.equal(1)
   const incomplete = reader.get('l/one/two')
-  same(incomplete.remaining, 'one/two')
+  expect(incomplete).to.have.property('remaining', 'one/two')
   assert.ok(CID.isCID(incomplete.value))
 })
 
 test('source optimization', () => {
   let reader = mock.reader({ source: () => fixture })
   let one = reader.get('/a/1').value
-  same(one, 1)
+  expect(one).to.equal(1)
   reader = mock.reader({ source: () => null, decode: () => fixture })
   one = reader.get('/a/1').value
-  same(one, 1)
+  expect(one).to.equal(1)
 })
 
 test('links', () => {
   const reader = getReader()
   const links = Array.from(reader.links())
   const keys = new Set(links.map(a => a[0]))
-  same(keys, new Set(['a/2', 'a/4/l', 'l', 'o/l']))
+  expect(keys).to.deep.equal(new Set(['a/2', 'a/4/l', 'l', 'o/l']))
   links.forEach(l => assert.ok(CID.isCID(l[1])))
 })
 
 test('tree', () => {
   const reader = getReader()
   const tree = Array.from(reader.tree())
-  same(new Set(tree), new Set([
+  expect(new Set(tree)).to.deep.equal(new Set([
     'a',
     'a/0',
     'a/1',
@@ -77,7 +76,7 @@ test('property not found', () => {
     reader.get('notfound')
   } catch (e) {
     threw = true
-    same(e.message, 'Object has no property notfound')
+    expect(e).to.have.property('message', 'Object has no property notfound')
   }
   assert(threw)
 })


### PR DESCRIPTION
Updates aegir, adds missing node deps from tests so they run in browsers
with the new setup.

Removes tsame as it depends on node internals - since we have aegir here
just uses the bundled chai for assertions, no need for extra deps.